### PR TITLE
fix: allow comments in tsconfig.json files while keeping JSON strict

### DIFF
--- a/.changeset/fix-biome-tsconfig-comments.md
+++ b/.changeset/fix-biome-tsconfig-comments.md
@@ -1,0 +1,7 @@
+---
+'@nextnode/standards': patch
+---
+
+Fix Biome JSON parser to allow comments in tsconfig.json files
+
+Add override configuration in Biome to allow comments specifically for tsconfig\*.json files while maintaining strict JSON parsing for all other JSON files. This resolves parsing errors with TypeScript configuration files that use comments.

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
 	},
 	"peerDependencies": {
 		"@biomejs/biome": "^2.0.0",
-		"@commitlint/cli": "^18.0.0",
-		"@commitlint/config-conventional": "^18.0.0",
+		"@commitlint/cli": ">=18.0.0",
+		"@commitlint/config-conventional": ">=18.0.0",
 		"prettier": "^3.0.0"
 	},
 	"peerDependenciesMeta": {

--- a/src/biome/base.json
+++ b/src/biome/base.json
@@ -165,6 +165,15 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["**/tsconfig*.json"],
+			"json": {
+				"parser": {
+					"allowComments": true,
+					"allowTrailingCommas": false
+				}
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary
This PR includes changes across 5 files.

## Changes
 5 files changed, 43 insertions(+), 9 deletions(-)

### Recent Commits
- b0af439 fix: allow comments in tsconfig.json files while keeping JSON strict
- bfe20c2 fix: add --no-errors-on-unmatched to biome lint command
- bdbbb24 feat: configure Biome for JSON formatting with tab indentation

### Files Modified
- A	.changeset/json-formatter.md
- M	.lintstagedrc.json
- M	commitlint.config.js
- M	package.json
- M	src/biome/base.json

---
🤖 Generated with gprc made by Walid + Claude