### PR TITLE
Add shared TypeScript and Vitest configurations for NextNode projects

### DIFF
--- a/.changeset/shared-configs.md
+++ b/.changeset/shared-configs.md
@@ -1,0 +1,12 @@
+---
+'@nextnode/standards': minor
+---
+
+Add shared TypeScript and Vitest configurations
+
+- Add TypeScript configurations for Astro, Library, and Next.js projects
+- Add Vitest configurations for frontend (jsdom) and backend (node) environments
+- Export new configurations with proper peer dependencies for vite, vitest, and vite-tsconfig-paths
+- Frontend config includes mock cleanup and jsdom environment setup
+- Backend config uses Node environment with comprehensive coverage settings
+- All configurations follow NextNode strict typing standards and modern best practices

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
 		"@biomejs/biome": "^2.0.0",
 		"@commitlint/cli": "^19.0.0",
 		"@commitlint/config-conventional": "^19.0.0",
-		"prettier": "^3.0.0"
+		"prettier": "^3.0.0",
+		"vite": "^5.0.0",
+		"vite-tsconfig-paths": "^5.0.0",
+		"vitest": "^3.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@biomejs/biome": {
@@ -69,6 +72,15 @@
 			"optional": true
 		},
 		"prettier": {
+			"optional": true
+		},
+		"vite": {
+			"optional": true
+		},
+		"vite-tsconfig-paths": {
+			"optional": true
+		},
+		"vitest": {
 			"optional": true
 		}
 	},
@@ -85,7 +97,12 @@
 		"./biome": "./src/biome/base.json",
 		"./prettier": "./src/prettier/base.js",
 		"./prettier/astro": "./src/prettier/astro.js",
-		"./commitlint": "./src/commitlint/base.js"
+		"./commitlint": "./src/commitlint/base.js",
+		"./typescript/astro": "./src/typescript/tsconfig.astro.json",
+		"./typescript/library": "./src/typescript/tsconfig.library.json",
+		"./typescript/nextjs": "./src/typescript/tsconfig.nextjs.json",
+		"./vitest/frontend": "./src/vitest/vitest.frontend.js",
+		"./vitest/backend": "./src/vitest/vitest.backend.js"
 	},
 	"prettier": "./src/prettier/base.js"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,16 @@ settings:
 
 importers:
     .:
+        dependencies:
+            vite:
+                specifier: ^5.0.0
+                version: 5.4.20(@types/node@22.17.2)
+            vite-tsconfig-paths:
+                specifier: ^5.0.0
+                version: 5.1.4(typescript@5.8.3)(vite@5.4.20(@types/node@22.17.2))
+            vitest:
+                specifier: ^3.0.0
+                version: 3.2.4(@types/node@22.17.2)
         devDependencies:
             '@biomejs/biome':
                 specifier: ^2.2.4
@@ -390,6 +400,213 @@ packages:
             }
         engines: { node: '>=v18' }
 
+    '@esbuild/aix-ppc64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
+            }
+        engines: { node: '>=12' }
+        cpu: [ppc64]
+        os: [aix]
+
+    '@esbuild/android-arm64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm64]
+        os: [android]
+
+    '@esbuild/android-arm@0.21.5':
+        resolution:
+            {
+                integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm]
+        os: [android]
+
+    '@esbuild/android-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [android]
+
+    '@esbuild/darwin-arm64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@esbuild/darwin-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [darwin]
+
+    '@esbuild/freebsd-arm64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm64]
+        os: [freebsd]
+
+    '@esbuild/freebsd-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [freebsd]
+
+    '@esbuild/linux-arm64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm64]
+        os: [linux]
+
+    '@esbuild/linux-arm@0.21.5':
+        resolution:
+            {
+                integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm]
+        os: [linux]
+
+    '@esbuild/linux-ia32@0.21.5':
+        resolution:
+            {
+                integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [ia32]
+        os: [linux]
+
+    '@esbuild/linux-loong64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [loong64]
+        os: [linux]
+
+    '@esbuild/linux-mips64el@0.21.5':
+        resolution:
+            {
+                integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [mips64el]
+        os: [linux]
+
+    '@esbuild/linux-ppc64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
+            }
+        engines: { node: '>=12' }
+        cpu: [ppc64]
+        os: [linux]
+
+    '@esbuild/linux-riscv64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
+            }
+        engines: { node: '>=12' }
+        cpu: [riscv64]
+        os: [linux]
+
+    '@esbuild/linux-s390x@0.21.5':
+        resolution:
+            {
+                integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
+            }
+        engines: { node: '>=12' }
+        cpu: [s390x]
+        os: [linux]
+
+    '@esbuild/linux-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [linux]
+
+    '@esbuild/netbsd-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [netbsd]
+
+    '@esbuild/openbsd-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [openbsd]
+
+    '@esbuild/sunos-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [sunos]
+
+    '@esbuild/win32-arm64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
+            }
+        engines: { node: '>=12' }
+        cpu: [arm64]
+        os: [win32]
+
+    '@esbuild/win32-ia32@0.21.5':
+        resolution:
+            {
+                integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
+            }
+        engines: { node: '>=12' }
+        cpu: [ia32]
+        os: [win32]
+
+    '@esbuild/win32-x64@0.21.5':
+        resolution:
+            {
+                integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
+            }
+        engines: { node: '>=12' }
+        cpu: [x64]
+        os: [win32]
+
     '@inquirer/external-editor@1.0.2':
         resolution:
             {
@@ -401,6 +618,12 @@ packages:
         peerDependenciesMeta:
             '@types/node':
                 optional: true
+
+    '@jridgewell/sourcemap-codec@1.5.5':
+        resolution:
+            {
+                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+            }
 
     '@manypkg/find-root@1.1.0':
         resolution:
@@ -435,10 +658,204 @@ packages:
             }
         engines: { node: '>= 8' }
 
+    '@rollup/rollup-android-arm-eabi@4.52.2':
+        resolution:
+            {
+                integrity: sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==,
+            }
+        cpu: [arm]
+        os: [android]
+
+    '@rollup/rollup-android-arm64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==,
+            }
+        cpu: [arm64]
+        os: [android]
+
+    '@rollup/rollup-darwin-arm64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==,
+            }
+        cpu: [arm64]
+        os: [darwin]
+
+    '@rollup/rollup-darwin-x64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==,
+            }
+        cpu: [x64]
+        os: [darwin]
+
+    '@rollup/rollup-freebsd-arm64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==,
+            }
+        cpu: [arm64]
+        os: [freebsd]
+
+    '@rollup/rollup-freebsd-x64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==,
+            }
+        cpu: [x64]
+        os: [freebsd]
+
+    '@rollup/rollup-linux-arm-gnueabihf@4.52.2':
+        resolution:
+            {
+                integrity: sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==,
+            }
+        cpu: [arm]
+        os: [linux]
+
+    '@rollup/rollup-linux-arm-musleabihf@4.52.2':
+        resolution:
+            {
+                integrity: sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==,
+            }
+        cpu: [arm]
+        os: [linux]
+
+    '@rollup/rollup-linux-arm64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==,
+            }
+        cpu: [arm64]
+        os: [linux]
+
+    '@rollup/rollup-linux-arm64-musl@4.52.2':
+        resolution:
+            {
+                integrity: sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==,
+            }
+        cpu: [arm64]
+        os: [linux]
+
+    '@rollup/rollup-linux-loong64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==,
+            }
+        cpu: [loong64]
+        os: [linux]
+
+    '@rollup/rollup-linux-ppc64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==,
+            }
+        cpu: [ppc64]
+        os: [linux]
+
+    '@rollup/rollup-linux-riscv64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==,
+            }
+        cpu: [riscv64]
+        os: [linux]
+
+    '@rollup/rollup-linux-riscv64-musl@4.52.2':
+        resolution:
+            {
+                integrity: sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==,
+            }
+        cpu: [riscv64]
+        os: [linux]
+
+    '@rollup/rollup-linux-s390x-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==,
+            }
+        cpu: [s390x]
+        os: [linux]
+
+    '@rollup/rollup-linux-x64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==,
+            }
+        cpu: [x64]
+        os: [linux]
+
+    '@rollup/rollup-linux-x64-musl@4.52.2':
+        resolution:
+            {
+                integrity: sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==,
+            }
+        cpu: [x64]
+        os: [linux]
+
+    '@rollup/rollup-openharmony-arm64@4.52.2':
+        resolution:
+            {
+                integrity: sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==,
+            }
+        cpu: [arm64]
+        os: [openharmony]
+
+    '@rollup/rollup-win32-arm64-msvc@4.52.2':
+        resolution:
+            {
+                integrity: sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==,
+            }
+        cpu: [arm64]
+        os: [win32]
+
+    '@rollup/rollup-win32-ia32-msvc@4.52.2':
+        resolution:
+            {
+                integrity: sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==,
+            }
+        cpu: [ia32]
+        os: [win32]
+
+    '@rollup/rollup-win32-x64-gnu@4.52.2':
+        resolution:
+            {
+                integrity: sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==,
+            }
+        cpu: [x64]
+        os: [win32]
+
+    '@rollup/rollup-win32-x64-msvc@4.52.2':
+        resolution:
+            {
+                integrity: sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==,
+            }
+        cpu: [x64]
+        os: [win32]
+
+    '@types/chai@5.2.2':
+        resolution:
+            {
+                integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==,
+            }
+
     '@types/conventional-commits-parser@5.0.1':
         resolution:
             {
                 integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==,
+            }
+
+    '@types/deep-eql@4.0.2':
+        resolution:
+            {
+                integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+            }
+
+    '@types/estree@1.0.8':
+        resolution:
+            {
+                integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
             }
 
     '@types/node@12.20.55':
@@ -451,6 +868,56 @@ packages:
         resolution:
             {
                 integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==,
+            }
+
+    '@vitest/expect@3.2.4':
+        resolution:
+            {
+                integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
+            }
+
+    '@vitest/mocker@3.2.4':
+        resolution:
+            {
+                integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
+            }
+        peerDependencies:
+            msw: ^2.4.9
+            vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+        peerDependenciesMeta:
+            msw:
+                optional: true
+            vite:
+                optional: true
+
+    '@vitest/pretty-format@3.2.4':
+        resolution:
+            {
+                integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
+            }
+
+    '@vitest/runner@3.2.4':
+        resolution:
+            {
+                integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
+            }
+
+    '@vitest/snapshot@3.2.4':
+        resolution:
+            {
+                integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
+            }
+
+    '@vitest/spy@3.2.4':
+        resolution:
+            {
+                integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
+            }
+
+    '@vitest/utils@3.2.4':
+        resolution:
+            {
+                integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
             }
 
     JSONStream@1.3.5:
@@ -533,6 +1000,13 @@ packages:
             }
         engines: { node: '>=8' }
 
+    assertion-error@2.0.1:
+        resolution:
+            {
+                integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+            }
+        engines: { node: '>=12' }
+
     better-path-resolve@1.0.0:
         resolution:
             {
@@ -552,6 +1026,13 @@ packages:
         resolution:
             {
                 integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+            }
+        engines: { node: '>=8' }
+
+    cac@6.7.14:
+        resolution:
+            {
+                integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
             }
         engines: { node: '>=8' }
 
@@ -583,6 +1064,13 @@ packages:
             }
         engines: { node: '>=6' }
 
+    chai@5.3.3:
+        resolution:
+            {
+                integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+            }
+        engines: { node: '>=18' }
+
     chalk@5.4.1:
         resolution:
             {
@@ -595,6 +1083,13 @@ packages:
             {
                 integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==,
             }
+
+    check-error@2.1.1:
+        resolution:
+            {
+                integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==,
+            }
+        engines: { node: '>= 16' }
 
     ci-info@3.9.0:
         resolution:
@@ -733,6 +1228,13 @@ packages:
             supports-color:
                 optional: true
 
+    deep-eql@5.0.2:
+        resolution:
+            {
+                integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+            }
+        engines: { node: '>=6' }
+
     define-data-property@1.1.4:
         resolution:
             {
@@ -828,12 +1330,26 @@ packages:
             }
         engines: { node: '>= 0.4' }
 
+    es-module-lexer@1.7.0:
+        resolution:
+            {
+                integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+            }
+
     es-object-atoms@1.1.1:
         resolution:
             {
                 integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
             }
         engines: { node: '>= 0.4' }
+
+    esbuild@0.21.5:
+        resolution:
+            {
+                integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
+            }
+        engines: { node: '>=12' }
+        hasBin: true
 
     escalade@3.2.0:
         resolution:
@@ -850,6 +1366,12 @@ packages:
         engines: { node: '>=4' }
         hasBin: true
 
+    estree-walker@3.0.3:
+        resolution:
+            {
+                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+            }
+
     eventemitter3@5.0.1:
         resolution:
             {
@@ -862,6 +1384,13 @@ packages:
                 integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==,
             }
         engines: { node: '>=16.17' }
+
+    expect-type@1.2.2:
+        resolution:
+            {
+                integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==,
+            }
+        engines: { node: '>=12.0.0' }
 
     extendable-error@0.1.7:
         resolution:
@@ -893,6 +1422,18 @@ packages:
             {
                 integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==,
             }
+
+    fdir@6.5.0:
+        resolution:
+            {
+                integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+            }
+        engines: { node: '>=12.0.0' }
+        peerDependencies:
+            picomatch: ^3 || ^4
+        peerDependenciesMeta:
+            picomatch:
+                optional: true
 
     fill-range@7.1.1:
         resolution:
@@ -928,6 +1469,14 @@ packages:
                 integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
             }
         engines: { node: '>=6 <7 || >=8' }
+
+    fsevents@2.3.3:
+        resolution:
+            {
+                integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+            }
+        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+        os: [darwin]
 
     function-bind@1.1.2:
         resolution:
@@ -998,6 +1547,12 @@ packages:
                 integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
             }
         engines: { node: '>=10' }
+
+    globrex@0.1.2:
+        resolution:
+            {
+                integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
+            }
 
     gopd@1.2.0:
         resolution:
@@ -1196,6 +1751,12 @@ packages:
                 integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
             }
 
+    js-tokens@9.0.1:
+        resolution:
+            {
+                integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
+            }
+
     js-yaml@3.14.1:
         resolution:
             {
@@ -1351,6 +1912,18 @@ packages:
             }
         engines: { node: '>=18' }
 
+    loupe@3.2.1:
+        resolution:
+            {
+                integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
+            }
+
+    magic-string@0.30.19:
+        resolution:
+            {
+                integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==,
+            }
+
     math-intrinsics@1.1.0:
         resolution:
             {
@@ -1417,6 +1990,14 @@ packages:
             {
                 integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
             }
+
+    nanoid@3.3.11:
+        resolution:
+            {
+                integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+            }
+        engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+        hasBin: true
 
     node-fetch@2.7.0:
         resolution:
@@ -1568,6 +2149,19 @@ packages:
             }
         engines: { node: '>=8' }
 
+    pathe@2.0.3:
+        resolution:
+            {
+                integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+            }
+
+    pathval@2.0.1:
+        resolution:
+            {
+                integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+            }
+        engines: { node: '>= 14.16' }
+
     picocolors@1.1.1:
         resolution:
             {
@@ -1580,6 +2174,13 @@ packages:
                 integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
             }
         engines: { node: '>=8.6' }
+
+    picomatch@4.0.3:
+        resolution:
+            {
+                integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+            }
+        engines: { node: '>=12' }
 
     pidtree@0.6.0:
         resolution:
@@ -1595,6 +2196,13 @@ packages:
                 integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
             }
         engines: { node: '>=6' }
+
+    postcss@8.5.6:
+        resolution:
+            {
+                integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+            }
+        engines: { node: ^10 || ^12 || >=14 }
 
     prettier-plugin-astro@0.14.1:
         resolution:
@@ -1750,6 +2358,14 @@ packages:
                 integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
             }
 
+    rollup@4.52.2:
+        resolution:
+            {
+                integrity: sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==,
+            }
+        engines: { node: '>=18.0.0', npm: '>=8.0.0' }
+        hasBin: true
+
     run-parallel@1.2.0:
         resolution:
             {
@@ -1803,6 +2419,12 @@ packages:
             }
         engines: { node: '>=8' }
 
+    siginfo@2.0.0:
+        resolution:
+            {
+                integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+            }
+
     signal-exit@4.1.0:
         resolution:
             {
@@ -1831,6 +2453,13 @@ packages:
             }
         engines: { node: '>=18' }
 
+    source-map-js@1.2.1:
+        resolution:
+            {
+                integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+            }
+        engines: { node: '>=0.10.0' }
+
     spawndamnit@3.0.1:
         resolution:
             {
@@ -1848,6 +2477,18 @@ packages:
         resolution:
             {
                 integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+            }
+
+    stackback@0.0.2:
+        resolution:
+            {
+                integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+            }
+
+    std-env@3.9.0:
+        resolution:
+            {
+                integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==,
             }
 
     string-argv@0.3.2:
@@ -1899,6 +2540,12 @@ packages:
             }
         engines: { node: '>=12' }
 
+    strip-literal@3.0.0:
+        resolution:
+            {
+                integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==,
+            }
+
     suf-log@2.5.3:
         resolution:
             {
@@ -1925,11 +2572,51 @@ packages:
                 integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
             }
 
+    tinybench@2.9.0:
+        resolution:
+            {
+                integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+            }
+
+    tinyexec@0.3.2:
+        resolution:
+            {
+                integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+            }
+
     tinyexec@1.0.1:
         resolution:
             {
                 integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==,
             }
+
+    tinyglobby@0.2.15:
+        resolution:
+            {
+                integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+            }
+        engines: { node: '>=12.0.0' }
+
+    tinypool@1.1.1:
+        resolution:
+            {
+                integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+            }
+        engines: { node: ^18.0.0 || >=20.0.0 }
+
+    tinyrainbow@2.0.0:
+        resolution:
+            {
+                integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
+            }
+        engines: { node: '>=14.0.0' }
+
+    tinyspy@4.0.4:
+        resolution:
+            {
+                integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
+            }
+        engines: { node: '>=14.0.0' }
 
     to-regex-range@5.0.1:
         resolution:
@@ -1943,6 +2630,19 @@ packages:
             {
                 integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
             }
+
+    tsconfck@3.1.6:
+        resolution:
+            {
+                integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
+            }
+        engines: { node: ^18 || >=20 }
+        hasBin: true
+        peerDependencies:
+            typescript: ^5.0.0
+        peerDependenciesMeta:
+            typescript:
+                optional: true
 
     typescript@5.8.3:
         resolution:
@@ -1972,6 +2672,90 @@ packages:
             }
         engines: { node: '>= 4.0.0' }
 
+    vite-node@3.2.4:
+        resolution:
+            {
+                integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
+            }
+        engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+        hasBin: true
+
+    vite-tsconfig-paths@5.1.4:
+        resolution:
+            {
+                integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==,
+            }
+        peerDependencies:
+            vite: '*'
+        peerDependenciesMeta:
+            vite:
+                optional: true
+
+    vite@5.4.20:
+        resolution:
+            {
+                integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==,
+            }
+        engines: { node: ^18.0.0 || >=20.0.0 }
+        hasBin: true
+        peerDependencies:
+            '@types/node': ^18.0.0 || >=20.0.0
+            less: '*'
+            lightningcss: ^1.21.0
+            sass: '*'
+            sass-embedded: '*'
+            stylus: '*'
+            sugarss: '*'
+            terser: ^5.4.0
+        peerDependenciesMeta:
+            '@types/node':
+                optional: true
+            less:
+                optional: true
+            lightningcss:
+                optional: true
+            sass:
+                optional: true
+            sass-embedded:
+                optional: true
+            stylus:
+                optional: true
+            sugarss:
+                optional: true
+            terser:
+                optional: true
+
+    vitest@3.2.4:
+        resolution:
+            {
+                integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
+            }
+        engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+        hasBin: true
+        peerDependencies:
+            '@edge-runtime/vm': '*'
+            '@types/debug': ^4.1.12
+            '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+            '@vitest/browser': 3.2.4
+            '@vitest/ui': 3.2.4
+            happy-dom: '*'
+            jsdom: '*'
+        peerDependenciesMeta:
+            '@edge-runtime/vm':
+                optional: true
+            '@types/debug':
+                optional: true
+            '@types/node':
+                optional: true
+            '@vitest/browser':
+                optional: true
+            '@vitest/ui':
+                optional: true
+            happy-dom:
+                optional: true
+            jsdom:
+                optional: true
+
     webidl-conversions@3.0.1:
         resolution:
             {
@@ -1990,6 +2774,14 @@ packages:
                 integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
             }
         engines: { node: '>= 8' }
+        hasBin: true
+
+    why-is-node-running@2.3.0:
+        resolution:
+            {
+                integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+            }
+        engines: { node: '>=8' }
         hasBin: true
 
     wrap-ansi@7.0.0:
@@ -2359,12 +3151,83 @@ snapshots:
             '@types/conventional-commits-parser': 5.0.1
             chalk: 5.4.1
 
+    '@esbuild/aix-ppc64@0.21.5':
+        optional: true
+
+    '@esbuild/android-arm64@0.21.5':
+        optional: true
+
+    '@esbuild/android-arm@0.21.5':
+        optional: true
+
+    '@esbuild/android-x64@0.21.5':
+        optional: true
+
+    '@esbuild/darwin-arm64@0.21.5':
+        optional: true
+
+    '@esbuild/darwin-x64@0.21.5':
+        optional: true
+
+    '@esbuild/freebsd-arm64@0.21.5':
+        optional: true
+
+    '@esbuild/freebsd-x64@0.21.5':
+        optional: true
+
+    '@esbuild/linux-arm64@0.21.5':
+        optional: true
+
+    '@esbuild/linux-arm@0.21.5':
+        optional: true
+
+    '@esbuild/linux-ia32@0.21.5':
+        optional: true
+
+    '@esbuild/linux-loong64@0.21.5':
+        optional: true
+
+    '@esbuild/linux-mips64el@0.21.5':
+        optional: true
+
+    '@esbuild/linux-ppc64@0.21.5':
+        optional: true
+
+    '@esbuild/linux-riscv64@0.21.5':
+        optional: true
+
+    '@esbuild/linux-s390x@0.21.5':
+        optional: true
+
+    '@esbuild/linux-x64@0.21.5':
+        optional: true
+
+    '@esbuild/netbsd-x64@0.21.5':
+        optional: true
+
+    '@esbuild/openbsd-x64@0.21.5':
+        optional: true
+
+    '@esbuild/sunos-x64@0.21.5':
+        optional: true
+
+    '@esbuild/win32-arm64@0.21.5':
+        optional: true
+
+    '@esbuild/win32-ia32@0.21.5':
+        optional: true
+
+    '@esbuild/win32-x64@0.21.5':
+        optional: true
+
     '@inquirer/external-editor@1.0.2(@types/node@22.17.2)':
         dependencies:
             chardet: 2.1.0
             iconv-lite: 0.7.0
         optionalDependencies:
             '@types/node': 22.17.2
+
+    '@jridgewell/sourcemap-codec@1.5.5': {}
 
     '@manypkg/find-root@1.1.0':
         dependencies:
@@ -2394,15 +3257,131 @@ snapshots:
             '@nodelib/fs.scandir': 2.1.5
             fastq: 1.19.1
 
+    '@rollup/rollup-android-arm-eabi@4.52.2':
+        optional: true
+
+    '@rollup/rollup-android-arm64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-darwin-arm64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-darwin-x64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-freebsd-arm64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-freebsd-x64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-arm-gnueabihf@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-arm-musleabihf@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-arm64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-arm64-musl@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-loong64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-ppc64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-riscv64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-riscv64-musl@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-s390x-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-x64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-linux-x64-musl@4.52.2':
+        optional: true
+
+    '@rollup/rollup-openharmony-arm64@4.52.2':
+        optional: true
+
+    '@rollup/rollup-win32-arm64-msvc@4.52.2':
+        optional: true
+
+    '@rollup/rollup-win32-ia32-msvc@4.52.2':
+        optional: true
+
+    '@rollup/rollup-win32-x64-gnu@4.52.2':
+        optional: true
+
+    '@rollup/rollup-win32-x64-msvc@4.52.2':
+        optional: true
+
+    '@types/chai@5.2.2':
+        dependencies:
+            '@types/deep-eql': 4.0.2
+
     '@types/conventional-commits-parser@5.0.1':
         dependencies:
             '@types/node': 22.17.2
+
+    '@types/deep-eql@4.0.2': {}
+
+    '@types/estree@1.0.8': {}
 
     '@types/node@12.20.55': {}
 
     '@types/node@22.17.2':
         dependencies:
             undici-types: 6.21.0
+
+    '@vitest/expect@3.2.4':
+        dependencies:
+            '@types/chai': 5.2.2
+            '@vitest/spy': 3.2.4
+            '@vitest/utils': 3.2.4
+            chai: 5.3.3
+            tinyrainbow: 2.0.0
+
+    '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.17.2))':
+        dependencies:
+            '@vitest/spy': 3.2.4
+            estree-walker: 3.0.3
+            magic-string: 0.30.19
+        optionalDependencies:
+            vite: 5.4.20(@types/node@22.17.2)
+
+    '@vitest/pretty-format@3.2.4':
+        dependencies:
+            tinyrainbow: 2.0.0
+
+    '@vitest/runner@3.2.4':
+        dependencies:
+            '@vitest/utils': 3.2.4
+            pathe: 2.0.3
+            strip-literal: 3.0.0
+
+    '@vitest/snapshot@3.2.4':
+        dependencies:
+            '@vitest/pretty-format': 3.2.4
+            magic-string: 0.30.19
+            pathe: 2.0.3
+
+    '@vitest/spy@3.2.4':
+        dependencies:
+            tinyspy: 4.0.4
+
+    '@vitest/utils@3.2.4':
+        dependencies:
+            '@vitest/pretty-format': 3.2.4
+            loupe: 3.2.1
+            tinyrainbow: 2.0.0
 
     JSONStream@1.3.5:
         dependencies:
@@ -2442,6 +3421,8 @@ snapshots:
 
     array-union@2.1.0: {}
 
+    assertion-error@2.0.1: {}
+
     better-path-resolve@1.0.0:
         dependencies:
             is-windows: 1.0.2
@@ -2453,6 +3434,8 @@ snapshots:
     braces@3.0.3:
         dependencies:
             fill-range: 7.1.1
+
+    cac@6.7.14: {}
 
     call-bind-apply-helpers@1.0.2:
         dependencies:
@@ -2473,9 +3456,19 @@ snapshots:
 
     callsites@3.1.0: {}
 
+    chai@5.3.3:
+        dependencies:
+            assertion-error: 2.0.1
+            check-error: 2.1.1
+            deep-eql: 5.0.2
+            loupe: 3.2.1
+            pathval: 2.0.1
+
     chalk@5.4.1: {}
 
     chardet@2.1.0: {}
+
+    check-error@2.1.1: {}
 
     ci-info@3.9.0: {}
 
@@ -2554,6 +3547,8 @@ snapshots:
         dependencies:
             ms: 2.1.3
 
+    deep-eql@5.0.2: {}
+
     define-data-property@1.1.4:
         dependencies:
             es-define-property: 1.0.1
@@ -2599,13 +3594,45 @@ snapshots:
 
     es-errors@1.3.0: {}
 
+    es-module-lexer@1.7.0: {}
+
     es-object-atoms@1.1.1:
         dependencies:
             es-errors: 1.3.0
 
+    esbuild@0.21.5:
+        optionalDependencies:
+            '@esbuild/aix-ppc64': 0.21.5
+            '@esbuild/android-arm': 0.21.5
+            '@esbuild/android-arm64': 0.21.5
+            '@esbuild/android-x64': 0.21.5
+            '@esbuild/darwin-arm64': 0.21.5
+            '@esbuild/darwin-x64': 0.21.5
+            '@esbuild/freebsd-arm64': 0.21.5
+            '@esbuild/freebsd-x64': 0.21.5
+            '@esbuild/linux-arm': 0.21.5
+            '@esbuild/linux-arm64': 0.21.5
+            '@esbuild/linux-ia32': 0.21.5
+            '@esbuild/linux-loong64': 0.21.5
+            '@esbuild/linux-mips64el': 0.21.5
+            '@esbuild/linux-ppc64': 0.21.5
+            '@esbuild/linux-riscv64': 0.21.5
+            '@esbuild/linux-s390x': 0.21.5
+            '@esbuild/linux-x64': 0.21.5
+            '@esbuild/netbsd-x64': 0.21.5
+            '@esbuild/openbsd-x64': 0.21.5
+            '@esbuild/sunos-x64': 0.21.5
+            '@esbuild/win32-arm64': 0.21.5
+            '@esbuild/win32-ia32': 0.21.5
+            '@esbuild/win32-x64': 0.21.5
+
     escalade@3.2.0: {}
 
     esprima@4.0.1: {}
+
+    estree-walker@3.0.3:
+        dependencies:
+            '@types/estree': 1.0.8
 
     eventemitter3@5.0.1: {}
 
@@ -2620,6 +3647,8 @@ snapshots:
             onetime: 6.0.0
             signal-exit: 4.1.0
             strip-final-newline: 3.0.0
+
+    expect-type@1.2.2: {}
 
     extendable-error@0.1.7: {}
 
@@ -2638,6 +3667,10 @@ snapshots:
     fastq@1.19.1:
         dependencies:
             reusify: 1.1.0
+
+    fdir@6.5.0(picomatch@4.0.3):
+        optionalDependencies:
+            picomatch: 4.0.3
 
     fill-range@7.1.1:
         dependencies:
@@ -2665,6 +3698,9 @@ snapshots:
             graceful-fs: 4.2.11
             jsonfile: 4.0.0
             universalify: 0.1.2
+
+    fsevents@2.3.3:
+        optional: true
 
     function-bind@1.1.2: {}
 
@@ -2714,6 +3750,8 @@ snapshots:
             ignore: 5.3.2
             merge2: 1.4.1
             slash: 3.0.0
+
+    globrex@0.1.2: {}
 
     gopd@1.2.0: {}
 
@@ -2789,6 +3827,8 @@ snapshots:
     jiti@2.5.1: {}
 
     js-tokens@4.0.0: {}
+
+    js-tokens@9.0.1: {}
 
     js-yaml@3.14.1:
         dependencies:
@@ -2881,6 +3921,12 @@ snapshots:
             strip-ansi: 7.1.0
             wrap-ansi: 9.0.0
 
+    loupe@3.2.1: {}
+
+    magic-string@0.30.19:
+        dependencies:
+            '@jridgewell/sourcemap-codec': 1.5.5
+
     math-intrinsics@1.1.0: {}
 
     meow@12.1.1: {}
@@ -2903,6 +3949,8 @@ snapshots:
     mri@1.2.0: {}
 
     ms@2.1.3: {}
+
+    nanoid@3.3.11: {}
 
     node-fetch@2.7.0:
         dependencies:
@@ -2973,13 +4021,25 @@ snapshots:
 
     path-type@4.0.0: {}
 
+    pathe@2.0.3: {}
+
+    pathval@2.0.1: {}
+
     picocolors@1.1.1: {}
 
     picomatch@2.3.1: {}
 
+    picomatch@4.0.3: {}
+
     pidtree@0.6.0: {}
 
     pify@4.0.1: {}
+
+    postcss@8.5.6:
+        dependencies:
+            nanoid: 3.3.11
+            picocolors: 1.1.1
+            source-map-js: 1.2.1
 
     prettier-plugin-astro@0.14.1:
         dependencies:
@@ -3025,6 +4085,34 @@ snapshots:
 
     rfdc@1.4.1: {}
 
+    rollup@4.52.2:
+        dependencies:
+            '@types/estree': 1.0.8
+        optionalDependencies:
+            '@rollup/rollup-android-arm-eabi': 4.52.2
+            '@rollup/rollup-android-arm64': 4.52.2
+            '@rollup/rollup-darwin-arm64': 4.52.2
+            '@rollup/rollup-darwin-x64': 4.52.2
+            '@rollup/rollup-freebsd-arm64': 4.52.2
+            '@rollup/rollup-freebsd-x64': 4.52.2
+            '@rollup/rollup-linux-arm-gnueabihf': 4.52.2
+            '@rollup/rollup-linux-arm-musleabihf': 4.52.2
+            '@rollup/rollup-linux-arm64-gnu': 4.52.2
+            '@rollup/rollup-linux-arm64-musl': 4.52.2
+            '@rollup/rollup-linux-loong64-gnu': 4.52.2
+            '@rollup/rollup-linux-ppc64-gnu': 4.52.2
+            '@rollup/rollup-linux-riscv64-gnu': 4.52.2
+            '@rollup/rollup-linux-riscv64-musl': 4.52.2
+            '@rollup/rollup-linux-s390x-gnu': 4.52.2
+            '@rollup/rollup-linux-x64-gnu': 4.52.2
+            '@rollup/rollup-linux-x64-musl': 4.52.2
+            '@rollup/rollup-openharmony-arm64': 4.52.2
+            '@rollup/rollup-win32-arm64-msvc': 4.52.2
+            '@rollup/rollup-win32-ia32-msvc': 4.52.2
+            '@rollup/rollup-win32-x64-gnu': 4.52.2
+            '@rollup/rollup-win32-x64-msvc': 4.52.2
+            fsevents: 2.3.3
+
     run-parallel@1.2.0:
         dependencies:
             queue-microtask: 1.2.3
@@ -3054,6 +4142,8 @@ snapshots:
 
     shebang-regex@3.0.0: {}
 
+    siginfo@2.0.0: {}
+
     signal-exit@4.1.0: {}
 
     slash@3.0.0: {}
@@ -3068,6 +4158,8 @@ snapshots:
             ansi-styles: 6.2.1
             is-fullwidth-code-point: 5.0.0
 
+    source-map-js@1.2.1: {}
+
     spawndamnit@3.0.1:
         dependencies:
             cross-spawn: 7.0.6
@@ -3076,6 +4168,10 @@ snapshots:
     split2@4.2.0: {}
 
     sprintf-js@1.0.3: {}
+
+    stackback@0.0.2: {}
+
+    std-env@3.9.0: {}
 
     string-argv@0.3.2: {}
 
@@ -3103,6 +4199,10 @@ snapshots:
 
     strip-final-newline@3.0.0: {}
 
+    strip-literal@3.0.0:
+        dependencies:
+            js-tokens: 9.0.1
+
     suf-log@2.5.3:
         dependencies:
             s.color: 0.0.15
@@ -3113,13 +4213,32 @@ snapshots:
 
     through@2.3.8: {}
 
+    tinybench@2.9.0: {}
+
+    tinyexec@0.3.2: {}
+
     tinyexec@1.0.1: {}
+
+    tinyglobby@0.2.15:
+        dependencies:
+            fdir: 6.5.0(picomatch@4.0.3)
+            picomatch: 4.0.3
+
+    tinypool@1.1.1: {}
+
+    tinyrainbow@2.0.0: {}
+
+    tinyspy@4.0.4: {}
 
     to-regex-range@5.0.1:
         dependencies:
             is-number: 7.0.0
 
     tr46@0.0.3: {}
+
+    tsconfck@3.1.6(typescript@5.8.3):
+        optionalDependencies:
+            typescript: 5.8.3
 
     typescript@5.8.3: {}
 
@@ -3128,6 +4247,82 @@ snapshots:
     unicorn-magic@0.1.0: {}
 
     universalify@0.1.2: {}
+
+    vite-node@3.2.4(@types/node@22.17.2):
+        dependencies:
+            cac: 6.7.14
+            debug: 4.4.1
+            es-module-lexer: 1.7.0
+            pathe: 2.0.3
+            vite: 5.4.20(@types/node@22.17.2)
+        transitivePeerDependencies:
+            - '@types/node'
+            - less
+            - lightningcss
+            - sass
+            - sass-embedded
+            - stylus
+            - sugarss
+            - supports-color
+            - terser
+
+    vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@5.4.20(@types/node@22.17.2)):
+        dependencies:
+            debug: 4.4.1
+            globrex: 0.1.2
+            tsconfck: 3.1.6(typescript@5.8.3)
+        optionalDependencies:
+            vite: 5.4.20(@types/node@22.17.2)
+        transitivePeerDependencies:
+            - supports-color
+            - typescript
+
+    vite@5.4.20(@types/node@22.17.2):
+        dependencies:
+            esbuild: 0.21.5
+            postcss: 8.5.6
+            rollup: 4.52.2
+        optionalDependencies:
+            '@types/node': 22.17.2
+            fsevents: 2.3.3
+
+    vitest@3.2.4(@types/node@22.17.2):
+        dependencies:
+            '@types/chai': 5.2.2
+            '@vitest/expect': 3.2.4
+            '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.17.2))
+            '@vitest/pretty-format': 3.2.4
+            '@vitest/runner': 3.2.4
+            '@vitest/snapshot': 3.2.4
+            '@vitest/spy': 3.2.4
+            '@vitest/utils': 3.2.4
+            chai: 5.3.3
+            debug: 4.4.1
+            expect-type: 1.2.2
+            magic-string: 0.30.19
+            pathe: 2.0.3
+            picomatch: 4.0.3
+            std-env: 3.9.0
+            tinybench: 2.9.0
+            tinyexec: 0.3.2
+            tinyglobby: 0.2.15
+            tinypool: 1.1.1
+            tinyrainbow: 2.0.0
+            vite: 5.4.20(@types/node@22.17.2)
+            vite-node: 3.2.4(@types/node@22.17.2)
+            why-is-node-running: 2.3.0
+        optionalDependencies:
+            '@types/node': 22.17.2
+        transitivePeerDependencies:
+            - less
+            - lightningcss
+            - msw
+            - sass
+            - sass-embedded
+            - stylus
+            - sugarss
+            - supports-color
+            - terser
 
     webidl-conversions@3.0.1: {}
 
@@ -3139,6 +4334,11 @@ snapshots:
     which@2.0.2:
         dependencies:
             isexe: 2.0.0
+
+    why-is-node-running@2.3.0:
+        dependencies:
+            siginfo: 2.0.0
+            stackback: 0.0.2
 
     wrap-ansi@7.0.0:
         dependencies:

--- a/src/typescript/tsconfig.astro.json
+++ b/src/typescript/tsconfig.astro.json
@@ -1,0 +1,24 @@
+{
+	"extends": "astro/tsconfigs/strict",
+	"compilerOptions": {
+		// Module System
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "es2022",
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+
+		// Type Safety
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+
+		// Output Configuration
+		"module": "preserve",
+		"noEmit": true,
+		"lib": ["es2022", "dom", "dom.iterable"]
+	}
+}

--- a/src/typescript/tsconfig.library.json
+++ b/src/typescript/tsconfig.library.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		// Target & Module Configuration
+		"target": "ES2023",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2023"],
+
+		// Type Safety Maximum - 100% Typé
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true,
+
+		// 100% ECMAScript - Library Ready
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"allowJs": true,
+
+		// Development Mode - No Emit
+		"noEmit": true
+	}
+}

--- a/src/typescript/tsconfig.nextjs.json
+++ b/src/typescript/tsconfig.nextjs.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		// Target & Module Configuration
+		"target": "ES2023",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"module": "esnext",
+		"moduleResolution": "bundler",
+
+		// JavaScript & JSON Support
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+
+		// Type Safety
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"forceConsistentCasingInFileNames": true,
+		"noImplicitOverride": true,
+
+		// Module System
+		"esModuleInterop": true,
+		"isolatedModules": true,
+
+		// JSX Configuration
+		"jsx": "preserve",
+
+		// Build Configuration
+		"incremental": true,
+		"noEmit": true
+	}
+}

--- a/src/vitest/vitest.backend.js
+++ b/src/vitest/vitest.backend.js
@@ -1,0 +1,33 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	// Vite Plugins
+	plugins: [tsconfigPaths()],
+
+	test: {
+		// Environment Configuration
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts'],
+		env: {
+			NODE_ENV: 'test',
+		},
+
+		// Coverage Configuration
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			reportsDirectory: './src/__tests__/coverage',
+			exclude: [
+				'node_modules/**',
+				'dist/**',
+				'**/*.d.ts',
+				'**/*.test.ts',
+				'**/*.spec.ts',
+				'**/*.config.ts',
+				'**/types.ts',
+			],
+		},
+	},
+})

--- a/src/vitest/vitest.frontend.js
+++ b/src/vitest/vitest.frontend.js
@@ -1,0 +1,39 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	// Vite Plugins
+	plugins: [tsconfigPaths()],
+
+	test: {
+		// Environment Configuration
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['./src/test/setup.ts'],
+
+		// Mock Cleanup Configuration
+		restoreMocks: true,
+		clearMocks: true,
+		unstubGlobals: true,
+		mockReset: false,
+
+		// Coverage Configuration
+		coverage: {
+			provider: 'v8',
+			reporter: ['json', 'html', 'text'],
+			reportsDirectory: './src/test/coverage',
+			enabled: true,
+			exclude: [
+				'**/*.test.ts',
+				'**/*.spec.ts',
+				'**/node_modules/**',
+				'**/dist/**',
+				'**/.astro/**',
+				'**/coverage/**',
+				'**/tests/**',
+				'**/config/**',
+				'**/types/**',
+			],
+		},
+	},
+})


### PR DESCRIPTION
## Summary
This PR adds shared TypeScript and Vitest configurations to the standards library, expanding beyond the existing Biome, Prettier, and Commitlint configurations to provide standardized setups for different project types.

## Changes

### Package Configuration
- **Added new dependencies**: `vite`, `vite-tsconfig-paths`, and `vitest` as optional peer dependencies
- **Extended exports**: Added 5 new exports for TypeScript configs (astro, library, nextjs) and Vitest configs (frontend, backend)

### TypeScript Configurations
- **Astro config** (`tsconfig.astro.json`): Extends Astro's strict config with ES2022 target, DOM libraries, and strict type safety settings including `noUncheckedIndexedAccess`
- **Library config** (`tsconfig.library.json`): Maximum type safety configuration for libraries with ES2023 target, ESNext modules, and comprehensive strict settings including `exactOptionalPropertyTypes` and `noUncheckedSideEffectImports`
- **Next.js config** (`tsconfig.nextjs.json`): Next.js-optimized setup with bundler module resolution, JSX preserve mode, and incremental compilation

### Vitest Configurations
- **Backend config** (`vitest.backend.js`): Node environment setup with TypeScript path mapping via `vite-tsconfig-paths`, V8 coverage provider, and test file patterns for server-side testing
- **Frontend config** (`vitest.frontend.js`): JSDOM environment for browser testing with mock cleanup configuration (`restoreMocks`, `clearMocks`, `unstubGlobals`), setup files support, and comprehensive coverage exclusions

All configurations follow the NextNode standards with strict type safety, modern ES modules, and comprehensive testing coverage setup.

---
🤖 Generated with gprc made by Walid + Claude