### PR TITLE
Update Vitest configurations and remove unnecessary TypeScript path dependency

### DIFF
--- a/.changeset/update-standards.md
+++ b/.changeset/update-standards.md
@@ -1,0 +1,5 @@
+---
+'@nextnode/standards': patch
+---
+
+Update standards documentation and configurations

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"@commitlint/config-conventional": "^19.0.0",
 		"prettier": "^3.0.0",
 		"vite": "^5.0.0",
-		"vite-tsconfig-paths": "^5.0.0",
 		"vitest": "^3.0.0"
 	},
 	"peerDependenciesMeta": {
@@ -75,9 +74,6 @@
 			"optional": true
 		},
 		"vite": {
-			"optional": true
-		},
-		"vite-tsconfig-paths": {
 			"optional": true
 		},
 		"vitest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,6 @@ importers:
             vite:
                 specifier: ^5.0.0
                 version: 5.4.20(@types/node@22.17.2)
-            vite-tsconfig-paths:
-                specifier: ^5.0.0
-                version: 5.1.4(typescript@5.8.3)(vite@5.4.20(@types/node@22.17.2))
             vitest:
                 specifier: ^3.0.0
                 version: 3.2.4(@types/node@22.17.2)
@@ -1548,12 +1545,6 @@ packages:
             }
         engines: { node: '>=10' }
 
-    globrex@0.1.2:
-        resolution:
-            {
-                integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
-            }
-
     gopd@1.2.0:
         resolution:
             {
@@ -2631,19 +2622,6 @@ packages:
                 integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
             }
 
-    tsconfck@3.1.6:
-        resolution:
-            {
-                integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
-            }
-        engines: { node: ^18 || >=20 }
-        hasBin: true
-        peerDependencies:
-            typescript: ^5.0.0
-        peerDependenciesMeta:
-            typescript:
-                optional: true
-
     typescript@5.8.3:
         resolution:
             {
@@ -2679,17 +2657,6 @@ packages:
             }
         engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
         hasBin: true
-
-    vite-tsconfig-paths@5.1.4:
-        resolution:
-            {
-                integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==,
-            }
-        peerDependencies:
-            vite: '*'
-        peerDependenciesMeta:
-            vite:
-                optional: true
 
     vite@5.4.20:
         resolution:
@@ -3751,8 +3718,6 @@ snapshots:
             merge2: 1.4.1
             slash: 3.0.0
 
-    globrex@0.1.2: {}
-
     gopd@1.2.0: {}
 
     graceful-fs@4.2.11: {}
@@ -4236,10 +4201,6 @@ snapshots:
 
     tr46@0.0.3: {}
 
-    tsconfck@3.1.6(typescript@5.8.3):
-        optionalDependencies:
-            typescript: 5.8.3
-
     typescript@5.8.3: {}
 
     undici-types@6.21.0: {}
@@ -4265,17 +4226,6 @@ snapshots:
             - sugarss
             - supports-color
             - terser
-
-    vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@5.4.20(@types/node@22.17.2)):
-        dependencies:
-            debug: 4.4.1
-            globrex: 0.1.2
-            tsconfck: 3.1.6(typescript@5.8.3)
-        optionalDependencies:
-            vite: 5.4.20(@types/node@22.17.2)
-        transitivePeerDependencies:
-            - supports-color
-            - typescript
 
     vite@5.4.20(@types/node@22.17.2):
         dependencies:

--- a/src/vitest/vitest.backend.js
+++ b/src/vitest/vitest.backend.js
@@ -1,10 +1,6 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-	// Vite Plugins
-	plugins: [tsconfigPaths()],
-
 	test: {
 		// Environment Configuration
 		globals: true,

--- a/src/vitest/vitest.frontend.js
+++ b/src/vitest/vitest.frontend.js
@@ -1,10 +1,6 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-	// Vite Plugins
-	plugins: [tsconfigPaths()],
-
 	test: {
 		// Environment Configuration
 		environment: 'jsdom',


### PR DESCRIPTION
## Summary
This PR removes the `vite-tsconfig-paths` dependency from Vitest configurations across backend and frontend setups, simplifying the configuration and reducing dependencies.

## Changes

### Package Dependencies
- **Removed `vite-tsconfig-paths` from devDependencies**: Eliminated the `^5.0.0` version from the main dependencies list
- **Removed optional peer dependency**: Cleaned up the `peerDependenciesMeta` section by removing the optional flag for `vite-tsconfig-paths`

### Vitest Configuration Updates
- **Backend configuration (`src/vitest/vitest.backend.js`)**: Removed the `tsconfigPaths()` plugin import and usage, simplifying the config to focus only on test settings
- **Frontend configuration (`src/vitest/vitest.frontend.js`)**: Applied the same cleanup, removing TypeScript path resolution plugin while maintaining jsdom environment setup

### Technical Impact
- **Dependency reduction**: Removes one optional dependency, reducing package complexity
- **Configuration simplification**: Both Vitest configs now have cleaner, more focused configurations
- **Path resolution**: Projects using these configurations will need to handle TypeScript path mapping through alternative means or rely on Vitest's built-in resolution

This change suggests that TypeScript path resolution is either no longer needed for the target use cases or is being handled by a different mechanism in the updated Vitest setup.

---
🤖 Generated with gprc made by Walid + Claude